### PR TITLE
Replaced Harcoded Space with Whitespace RegEx

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,8 +73,9 @@ const Functions =
 		'UNIX_TIMESTAMP\\(', 'UpdateXML\\(', 'UPPER\\(', 'USER\\(', 'UTC_DATE\\(', 'UTC_TIME\\(', 'UTC_TIMESTAMP\\(', 'UUID\\(', 'UUID_SHORT\\(', 'VALIDATE_PASSWORD_STRENGTH\\(', 'VALUES\\(', 'VAR_POP\\(',
 		'VAR_SAMP\\(', 'VARIANCE\\(', 'VERSION\\(', 'WAIT_FOR_EXECUTED_GTID_SET\\(', 'WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS\\(', 'WEEK\\(', 'WEEKDAY\\(', 'WEEKOFYEAR\\(', 'WEIGHT_STRING\\(', 'YEAR\\(', 'YEARWEEK\\('
 	];
-var mysqlKeywordRegEx = new RegExp("(?: " + Keywords.join(' | ') + " )", "gi");
-var mysqlFunctionRegEx = new RegExp("(?: " + Functions.join('|') + " )", "gi");
+const mysqlSpaceRegExSnippet = '(?: |\t|\r\n|\r|\n)'; // VSCode doesn't handle the \s meta-character. The \r\n permutations are to handle linefeeds in Windows, Mac & Linux respectively
+const mysqlKeywordRegEx = new RegExp(mysqlSpaceRegExSnippet + "(?:" + Keywords.join('|') + ")" + mysqlSpaceRegExSnippet, "gi");
+const mysqlFunctionRegEx = new RegExp("(?: " + Functions.join('|') + " )", "gi");
 const mysqlStringRegEx = /'(([^'])*)'/gi;
 const mysqlParamRegEx = /\?/gi;
 


### PR DESCRIPTION
The plugin requires to have a padding space on each side of the control words.
That's not too bad, unless you have a control character at the end of a line, and either have a trailing space the linter will flag or forgo the decorations on these control characters.

This PR aims to replace the hardcoded whitespace in the regex with the equivalent of the ` \s` RegEx meta-character  in VSCode.

Now, both my linter and the decorator can go along just fine!